### PR TITLE
fix: clear-cache.yml

### DIFF
--- a/.github/workflows/clear-cache.yml
+++ b/.github/workflows/clear-cache.yml
@@ -1,0 +1,27 @@
+name: Clear Cache
+on:
+  schedule:
+    # Runs at 00:00 UTC on Monday every two weeks
+    - cron: '0 0 */14 * MON'
+  workflow_dispatch:  # Manual trigger
+
+jobs:
+  clear-cache:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clear GitHub Actions cache
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const caches = await github.rest.actions.getActionsCacheList({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            })
+            for (const cache of caches.data.actions_caches) {
+              console.log('Clearing cache:', cache.id, cache.key)
+              await github.rest.actions.deleteActionsCacheById({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                cache_id: cache.id,
+              })
+            }

--- a/bot/src/autocomplete/vn/character.rs
+++ b/bot/src/autocomplete/vn/character.rs
@@ -1,4 +1,3 @@
-
 use crate::event_handler::BotData;
 use crate::helper::get_option::subcommand::get_option_map_string_autocomplete_subcommand;
 use crate::helper::vndbapi::character::{get_character, Character};

--- a/bot/src/autocomplete/vn/game.rs
+++ b/bot/src/autocomplete/vn/game.rs
@@ -1,4 +1,3 @@
-
 use crate::event_handler::BotData;
 use crate::helper::get_option::subcommand::get_option_map_string_autocomplete_subcommand;
 use crate::helper::vndbapi::game::{get_vn, VN};

--- a/bot/src/autocomplete/vn/producer.rs
+++ b/bot/src/autocomplete/vn/producer.rs
@@ -1,4 +1,3 @@
-
 use crate::event_handler::BotData;
 use crate::helper::get_option::subcommand::get_option_map_string_autocomplete_subcommand;
 use crate::helper::vndbapi::producer::{get_producer, Producer};

--- a/bot/src/background_task/update_random_stats.rs
+++ b/bot/src/background_task/update_random_stats.rs
@@ -199,7 +199,7 @@ async fn update_page(
             random_stats.anime_last_page += 1;
 
             random_stats.manga_last_page += 1;
-        } 
+        }
     }
 
     has_next_page

--- a/bot/src/command/command_trait.rs
+++ b/bot/src/command/command_trait.rs
@@ -7,9 +7,7 @@ use crate::event_handler::BotData;
 use crate::helper::create_default_embed::get_default_embed;
 use anyhow::Result;
 use serenity::all::CreateInteractionResponse::Defer;
-use serenity::all::{
-    CommandInteraction, CreateInteractionResponseMessage, SkuFlags, SkuId,
-};
+use serenity::all::{CommandInteraction, CreateInteractionResponseMessage, SkuFlags, SkuId};
 use serenity::builder::{
     CreateButton, CreateInteractionResponse, CreateInteractionResponseFollowup,
 };


### PR DESCRIPTION
This pull request includes several changes to the repository. The most important changes involve adding a new GitHub Actions workflow for clearing the cache and making various formatting adjustments in Rust files.

### GitHub Actions Workflow:

* [`.github/workflows/clear-cache.yml`](diffhunk://#diff-6e187e92d9552c1b31589e2fe5e873f9141db8a95f5a13288dba34bee678b073R1-R27): Added a new workflow to clear the GitHub Actions cache on a bi-weekly schedule and via manual trigger.

### Rust Code Formatting:

* [`bot/src/autocomplete/vn/character.rs`](diffhunk://#diff-5fc8f69a4c2a4e2cf7a0d9a7fb52c49959ab338f2c495f30988f145a7d99a1ccL1): Removed an unnecessary blank line at the beginning of the file.
* [`bot/src/autocomplete/vn/game.rs`](diffhunk://#diff-b4cbffda7190ac5887eb635a853b6028e74ef01ae2fdee8304cd1a60882b26edL1): Removed an unnecessary blank line at the beginning of the file.
* [`bot/src/autocomplete/vn/producer.rs`](diffhunk://#diff-abdaa7d4adbe8928028db5d73ea9eb3813a99c57b5efbd9b4670233ee4a2163fL1): Removed an unnecessary blank line at the beginning of the file.
* [`bot/src/command/command_trait.rs`](diffhunk://#diff-10b8ef29abfebd7762eea5ee3d6c2b13eac91cd0e47a770678d8a0183707d552L10-R10): Reformatted the `use` statements to be more concise.